### PR TITLE
feat: add support for SchallCircuitGroup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Changes:
+    - [item=cybersyn-provider-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.
+    - [item=cybersyn-requester-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.
+    - [item=cybersyn-delivery-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,2 @@
+-- Better subgroup placement with SchallCircuitGroup
+require("data-updates.schall-circuit-group")

--- a/data-updates/schall-circuit-group.lua
+++ b/data-updates/schall-circuit-group.lua
@@ -1,0 +1,5 @@
+if mods["SchallCircuitGroup"] then
+  data.raw.item["cybersyn-provider-reader"].subgroup = "circuit-input"
+  data.raw.item["cybersyn-requester-reader"].subgroup = "circuit-input"
+  data.raw.item["cybersyn-delivery-reader"].subgroup = "circuit-input"
+end

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.0",
-    "Cybersyn-Content-Reader >= 1.0.0"
+    "Cybersyn-Content-Reader >= 1.0.0",
+    "? SchallCircuitGroup >= 2.0.0"
   ]
 }


### PR DESCRIPTION
- [item=cybersyn-provider-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.
- [item=cybersyn-requester-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.
- [item=cybersyn-delivery-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.