### PR TITLE
feat: remove circuit-network-2 technology and update unlocks to cybersyn train network

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,3 +5,4 @@ Date: ????
     - [item=cybersyn-provider-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.
     - [item=cybersyn-requester-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.
     - [item=cybersyn-delivery-reader] Change subgroup to circuit-input if SchallCircuitGroup is installed.
+    - Remove circuit network 2 technology and move Cybersyn Content Reader unlocks to cybersyn train network technology.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,2 +1,5 @@
 -- Better subgroup placement with SchallCircuitGroup
 require("data-updates.schall-circuit-group")
+
+-- Remove circuit-network-2 technology and move unlocks to cybersyn-train-network technology
+require("data-updates.remove-circuit-network-2-tech")

--- a/data-updates/remove-circuit-network-2-tech.lua
+++ b/data-updates/remove-circuit-network-2-tech.lua
@@ -1,0 +1,5 @@
+data.raw.technology["circuit-network-2"] = nil
+
+table.insert(data.raw.technology["cybersyn-train-network"].effects, {type = "unlock-recipe", recipe = "cybersyn-provider-reader"})
+table.insert(data.raw.technology["cybersyn-train-network"].effects, {type = "unlock-recipe", recipe = "cybersyn-requester-reader"})
+table.insert(data.raw.technology["cybersyn-train-network"].effects, {type = "unlock-recipe", recipe = "cybersyn-delivery-reader"})


### PR DESCRIPTION
- Remove circuit network 2 technology and move Cybersyn Content Reader unlocks to cybersyn train network technology.